### PR TITLE
feat(api): 動的システムプロンプト生成の実装

### DIFF
--- a/apps/api/src/__tests__/chat-orchestrator.test.ts
+++ b/apps/api/src/__tests__/chat-orchestrator.test.ts
@@ -1,19 +1,56 @@
-import { ChatOrchestrator } from '../orchestrator/chat-orchestrator';
-import { SwitchBotClient } from '@llm-switchbot/switchbot-adapter';
-import { harmonyToolsSchema } from '@llm-switchbot/harmony-tools';
+import { ChatOrchestrator } from "../orchestrator/chat-orchestrator";
+import { SwitchBotClient } from "@llm-switchbot/switchbot-adapter";
+import { harmonyToolsSchema } from "@llm-switchbot/harmony-tools";
+import { FALLBACK_SYSTEM_PROMPT } from "../config/system-prompts";
 
 // SwitchBotClientをモック
-jest.mock('@llm-switchbot/switchbot-adapter');
-const MockedSwitchBotClient = SwitchBotClient as jest.MockedClass<typeof SwitchBotClient>;
+jest.mock("@llm-switchbot/switchbot-adapter");
+const MockedSwitchBotClient = SwitchBotClient as jest.MockedClass<
+  typeof SwitchBotClient
+>;
 
-describe('ChatOrchestrator', () => {
+describe("ChatOrchestrator", () => {
   let orchestrator: ChatOrchestrator;
   let mockSwitchBotClient: jest.Mocked<SwitchBotClient>;
 
+  const mockDevicesApiResponse = {
+    statusCode: 100,
+    message: "success",
+    body: {
+      deviceList: [
+        {
+          deviceId: "HUB-001",
+          deviceName: "ハブミニ",
+          deviceType: "Hub Mini",
+          enableCloudService: true,
+          hubDeviceId: "",
+        },
+        {
+          deviceId: "METER-001",
+          deviceName: "温湿度計",
+          deviceType: "MeterPlus",
+          enableCloudService: true,
+          hubDeviceId: "HUB-001",
+        },
+      ],
+      infraredRemoteList: [
+        {
+          deviceId: "IR-AC-001",
+          deviceName: "エアコン",
+          remoteType: "Air Conditioner",
+          hubDeviceId: "HUB-001",
+        },
+      ],
+    },
+  };
+
   beforeEach(() => {
     // SwitchBotClientのモックインスタンスを作成
-    mockSwitchBotClient = new MockedSwitchBotClient('test-token', 'test-secret') as jest.Mocked<SwitchBotClient>;
-    
+    mockSwitchBotClient = new MockedSwitchBotClient(
+      "test-token",
+      "test-secret",
+    ) as jest.Mocked<SwitchBotClient>;
+
     // メソッドをモック化
     mockSwitchBotClient.getDevices = jest.fn();
     mockSwitchBotClient.getDeviceStatus = jest.fn();
@@ -28,34 +65,38 @@ describe('ChatOrchestrator', () => {
     jest.clearAllMocks();
   });
 
-  describe('constructor', () => {
-    it('should initialize with SwitchBot client', () => {
+  describe("constructor", () => {
+    it("should initialize with SwitchBot client", () => {
       expect(orchestrator).toBeDefined();
       expect(orchestrator.getToolsSchema()).toEqual(harmonyToolsSchema);
     });
   });
 
-  describe('processToolCall', () => {
-    it('should handle get_devices tool call', async () => {
+  describe("processToolCall", () => {
+    it("should handle get_devices tool call", async () => {
       // Arrange
       const mockDevicesResponse = {
         statusCode: 100,
-        message: 'success',
+        message: "success",
         body: {
           deviceList: [
-            { deviceId: 'device-1', deviceName: 'Test Device', deviceType: 'Bot' }
-          ]
-        }
+            {
+              deviceId: "device-1",
+              deviceName: "Test Device",
+              deviceType: "Bot",
+            },
+          ],
+        },
       };
       mockSwitchBotClient.getDevices.mockResolvedValue(mockDevicesResponse);
 
       const toolCall = {
-        id: 'call-1',
-        type: 'function' as const,
+        id: "call-1",
+        type: "function" as const,
         function: {
-          name: 'get_devices',
-          arguments: '{}'
-        }
+          name: "get_devices",
+          arguments: "{}",
+        },
       };
 
       // Act
@@ -63,60 +104,62 @@ describe('ChatOrchestrator', () => {
 
       // Assert
       expect(mockSwitchBotClient.getDevices).toHaveBeenCalledTimes(1);
-      expect(result.tool_name).toBe('get_devices');
-      expect(result.status).toBe('success');
+      expect(result.tool_name).toBe("get_devices");
+      expect(result.status).toBe("success");
       expect(result.result).toEqual(mockDevicesResponse);
     });
 
-    it('should handle get_device_status tool call', async () => {
+    it("should handle get_device_status tool call", async () => {
       // Arrange
-      const deviceId = 'device-123';
+      const deviceId = "device-123";
       const mockStatusResponse = {
         statusCode: 100,
-        message: 'success',
-        body: { power: 'on', battery: 85 }
+        message: "success",
+        body: { power: "on", battery: 85 },
       };
       mockSwitchBotClient.getDeviceStatus.mockResolvedValue(mockStatusResponse);
 
       const toolCall = {
-        id: 'call-2',
-        type: 'function' as const,
+        id: "call-2",
+        type: "function" as const,
         function: {
-          name: 'get_device_status',
-          arguments: JSON.stringify({ deviceId })
-        }
+          name: "get_device_status",
+          arguments: JSON.stringify({ deviceId }),
+        },
       };
 
       // Act
       const result = await orchestrator.processToolCall(toolCall);
 
       // Assert
-      expect(mockSwitchBotClient.getDeviceStatus).toHaveBeenCalledWith(deviceId);
-      expect(result.tool_name).toBe('get_device_status');
-      expect(result.status).toBe('success');
+      expect(mockSwitchBotClient.getDeviceStatus).toHaveBeenCalledWith(
+        deviceId,
+      );
+      expect(result.tool_name).toBe("get_device_status");
+      expect(result.status).toBe("success");
       expect(result.result).toEqual(mockStatusResponse);
     });
 
-    it('should handle send_command tool call', async () => {
+    it("should handle send_command tool call", async () => {
       // Arrange
       const commandArgs = {
-        deviceId: 'device-123',
-        command: 'turnOn',
-        parameter: { temperature: 25 }
+        deviceId: "device-123",
+        command: "turnOn",
+        parameter: { temperature: 25 },
       };
       const mockCommandResponse = {
         statusCode: 100,
-        message: 'success'
+        message: "success",
       };
       mockSwitchBotClient.sendCommand.mockResolvedValue(mockCommandResponse);
 
       const toolCall = {
-        id: 'call-3',
-        type: 'function' as const,
+        id: "call-3",
+        type: "function" as const,
         function: {
-          name: 'send_command',
-          arguments: JSON.stringify(commandArgs)
-        }
+          name: "send_command",
+          arguments: JSON.stringify(commandArgs),
+        },
       };
 
       // Act
@@ -126,31 +169,29 @@ describe('ChatOrchestrator', () => {
       expect(mockSwitchBotClient.sendCommand).toHaveBeenCalledWith(
         commandArgs.deviceId,
         commandArgs.command,
-        commandArgs.parameter
+        commandArgs.parameter,
       );
-      expect(result.tool_name).toBe('send_command');
-      expect(result.status).toBe('success');
+      expect(result.tool_name).toBe("send_command");
+      expect(result.status).toBe("success");
       expect(result.result).toEqual(mockCommandResponse);
     });
 
-    it('should handle get_scenes tool call', async () => {
+    it("should handle get_scenes tool call", async () => {
       // Arrange
       const mockScenesResponse = {
         statusCode: 100,
-        message: 'success',
-        body: [
-          { sceneId: 'scene-1', sceneName: 'Morning Routine' }
-        ]
+        message: "success",
+        body: [{ sceneId: "scene-1", sceneName: "Morning Routine" }],
       };
       mockSwitchBotClient.getScenes.mockResolvedValue(mockScenesResponse);
 
       const toolCall = {
-        id: 'call-4',
-        type: 'function' as const,
+        id: "call-4",
+        type: "function" as const,
         function: {
-          name: 'get_scenes',
-          arguments: '{}'
-        }
+          name: "get_scenes",
+          arguments: "{}",
+        },
       };
 
       // Act
@@ -158,27 +199,27 @@ describe('ChatOrchestrator', () => {
 
       // Assert
       expect(mockSwitchBotClient.getScenes).toHaveBeenCalledTimes(1);
-      expect(result.tool_name).toBe('get_scenes');
-      expect(result.status).toBe('success');
+      expect(result.tool_name).toBe("get_scenes");
+      expect(result.status).toBe("success");
       expect(result.result).toEqual(mockScenesResponse);
     });
 
-    it('should handle execute_scene tool call', async () => {
+    it("should handle execute_scene tool call", async () => {
       // Arrange
-      const sceneId = 'scene-123';
+      const sceneId = "scene-123";
       const mockExecuteResponse = {
         statusCode: 100,
-        message: 'success'
+        message: "success",
       };
       mockSwitchBotClient.executeScene.mockResolvedValue(mockExecuteResponse);
 
       const toolCall = {
-        id: 'call-5',
-        type: 'function' as const,
+        id: "call-5",
+        type: "function" as const,
         function: {
-          name: 'execute_scene',
-          arguments: JSON.stringify({ sceneId })
-        }
+          name: "execute_scene",
+          arguments: JSON.stringify({ sceneId }),
+        },
       };
 
       // Act
@@ -186,87 +227,94 @@ describe('ChatOrchestrator', () => {
 
       // Assert
       expect(mockSwitchBotClient.executeScene).toHaveBeenCalledWith(sceneId);
-      expect(result.tool_name).toBe('execute_scene');
-      expect(result.status).toBe('success');
+      expect(result.tool_name).toBe("execute_scene");
+      expect(result.status).toBe("success");
       expect(result.result).toEqual(mockExecuteResponse);
     });
 
-    it('should handle unknown tool calls', async () => {
+    it("should handle unknown tool calls", async () => {
       // Arrange
       const toolCall = {
-        id: 'call-unknown',
-        type: 'function' as const,
+        id: "call-unknown",
+        type: "function" as const,
         function: {
-          name: 'unknown_tool',
-          arguments: '{}'
-        }
+          name: "unknown_tool",
+          arguments: "{}",
+        },
       };
 
       // Act
       const result = await orchestrator.processToolCall(toolCall);
 
       // Assert
-      expect(result.tool_name).toBe('unknown_tool');
-      expect(result.status).toBe('error');
-      expect(result.error_message).toContain('Unknown tool');
+      expect(result.tool_name).toBe("unknown_tool");
+      expect(result.status).toBe("error");
+      expect(result.error_message).toContain("Unknown tool");
     });
 
-    it('should handle invalid arguments', async () => {
+    it("should handle invalid arguments", async () => {
       // Arrange
       const toolCall = {
-        id: 'call-invalid',
-        type: 'function' as const,
+        id: "call-invalid",
+        type: "function" as const,
         function: {
-          name: 'send_command',
-          arguments: '{"deviceId": "test"}' // missing required 'command' parameter
-        }
+          name: "send_command",
+          arguments: '{"deviceId": "test"}', // missing required 'command' parameter
+        },
       };
 
       // Act
       const result = await orchestrator.processToolCall(toolCall);
 
       // Assert
-      expect(result.tool_name).toBe('send_command');
-      expect(result.status).toBe('error');
-      expect(result.error_message).toContain('Missing required parameter: command');
+      expect(result.tool_name).toBe("send_command");
+      expect(result.status).toBe("error");
+      expect(result.error_message).toContain(
+        "Missing required parameter: command",
+      );
     });
 
-    it('should handle SwitchBot API errors', async () => {
+    it("should handle SwitchBot API errors", async () => {
       // Arrange
       const toolCall = {
-        id: 'call-error',
-        type: 'function' as const,
+        id: "call-error",
+        type: "function" as const,
         function: {
-          name: 'get_devices',
-          arguments: '{}'
-        }
+          name: "get_devices",
+          arguments: "{}",
+        },
       };
 
-      mockSwitchBotClient.getDevices.mockRejectedValue(new Error('API Error: Device not found'));
+      mockSwitchBotClient.getDevices.mockRejectedValue(
+        new Error("API Error: Device not found"),
+      );
 
       // Act
       const result = await orchestrator.processToolCall(toolCall);
 
       // Assert
-      expect(result.tool_name).toBe('get_devices');
-      expect(result.status).toBe('error');
-      expect(result.error_message).toBe('API Error: Device not found');
+      expect(result.tool_name).toBe("get_devices");
+      expect(result.status).toBe("error");
+      expect(result.error_message).toBe("API Error: Device not found");
     });
 
-    it('should measure execution time', async () => {
+    it("should measure execution time", async () => {
       // Arrange
-      const mockResponse = { statusCode: 100, message: 'success', body: {} };
+      const mockResponse = { statusCode: 100, message: "success", body: {} };
       mockSwitchBotClient.getDevices.mockImplementation(
-        () => new Promise(resolve => setTimeout(() => resolve(mockResponse), 100))
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve(mockResponse), 100),
+          ),
       );
 
       const toolCall = {
-        id: 'call-timing',
-        type: 'function' as const,
+        id: "call-timing",
+        type: "function" as const,
         function: {
-          name: 'get_devices',
-          arguments: '{}'
-        }
+          name: "get_devices",
+          arguments: "{}",
+        },
       };
 
       // Act
@@ -278,12 +326,10 @@ describe('ChatOrchestrator', () => {
     });
   });
 
-  describe('processChat', () => {
-    it('should process messages without tool calls', async () => {
+  describe("processChat", () => {
+    it("should process messages without tool calls", async () => {
       // Arrange
-      const messages = [
-        { role: 'user' as const, content: 'こんにちは' }
-      ];
+      const messages = [{ role: "user" as const, content: "こんにちは" }];
 
       // Act
       const result = await orchestrator.processChat(messages);
@@ -291,20 +337,20 @@ describe('ChatOrchestrator', () => {
       // Assert
       expect(result.response).toBeDefined();
       expect(result.toolResults).toHaveLength(0);
-      expect(result.response.role).toBe('assistant');
-      expect(result.response.content).toContain('デモモード');
+      expect(result.response.role).toBe("assistant");
+      expect(result.response.content).toContain("デモモード");
     });
 
-    it('should process messages with tool calls', async () => {
+    it("should process messages with tool calls", async () => {
       // Arrange
       const messages = [
-        { role: 'user' as const, content: 'デバイス一覧を教えて' }
+        { role: "user" as const, content: "デバイス一覧を教えて" },
       ];
 
       const mockDevicesResponse = {
         statusCode: 100,
-        message: 'success',
-        body: { deviceList: [] }
+        message: "success",
+        body: { deviceList: [] },
       };
       mockSwitchBotClient.getDevices.mockResolvedValue(mockDevicesResponse);
 
@@ -314,7 +360,89 @@ describe('ChatOrchestrator', () => {
       // Assert
       expect(result.response).toBeDefined();
       expect(result.toolResults).toHaveLength(1);
-      expect(result.toolResults[0].tool_name).toBe('get_devices');
+      expect(result.toolResults[0].tool_name).toBe("get_devices");
+    });
+  });
+
+  describe("generateSystemMessage", () => {
+    it("should generate prompt with dynamic device info", async () => {
+      // Arrange
+      mockSwitchBotClient.getDevices.mockResolvedValue(mockDevicesApiResponse);
+
+      // Act
+      const message = await orchestrator.generateSystemMessage();
+
+      // Assert
+      expect(message.role).toBe("system");
+      expect(message.content).toContain("ハブミニ");
+      expect(message.content).toContain("HUB-001");
+      expect(message.content).toContain("温湿度計");
+      expect(message.content).toContain("エアコン");
+    });
+
+    it("should mark restricted devices in prompt", async () => {
+      // Arrange
+      mockSwitchBotClient.getDevices.mockResolvedValue(mockDevicesApiResponse);
+      const restrictedOrch = new ChatOrchestrator(
+        mockSwitchBotClient,
+        undefined,
+        {
+          restrictedDeviceIds: ["IR-AC-001"],
+        },
+      );
+
+      // Act
+      const message = await restrictedOrch.generateSystemMessage();
+
+      // Assert
+      expect(message.content).toContain("操作禁止");
+      expect(message.content).toContain("エアコン");
+    });
+
+    it("should use fallback prompt when device fetch fails", async () => {
+      // Arrange
+      mockSwitchBotClient.getDevices.mockRejectedValue(
+        new Error("Network error"),
+      );
+
+      // Act
+      const message = await orchestrator.generateSystemMessage();
+
+      // Assert
+      expect(message.role).toBe("system");
+      expect(message.content).toBe(FALLBACK_SYSTEM_PROMPT);
+    });
+
+    it("should cache device info for subsequent calls", async () => {
+      // Arrange
+      mockSwitchBotClient.getDevices.mockResolvedValue(mockDevicesApiResponse);
+
+      // Act
+      await orchestrator.generateSystemMessage();
+      await orchestrator.generateSystemMessage();
+
+      // Assert — API should be called only once due to caching
+      expect(mockSwitchBotClient.getDevices).toHaveBeenCalledTimes(1);
+    });
+
+    it("should refresh cache after TTL expires", async () => {
+      // Arrange
+      mockSwitchBotClient.getDevices.mockResolvedValue(mockDevicesApiResponse);
+      const shortTtlOrch = new ChatOrchestrator(
+        mockSwitchBotClient,
+        undefined,
+        {
+          promptCacheTtlMs: 50,
+        },
+      );
+
+      // Act
+      await shortTtlOrch.generateSystemMessage();
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      await shortTtlOrch.generateSystemMessage();
+
+      // Assert
+      expect(mockSwitchBotClient.getDevices).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/apps/api/src/__tests__/system-prompts.test.ts
+++ b/apps/api/src/__tests__/system-prompts.test.ts
@@ -1,0 +1,214 @@
+import {
+  generateSystemPrompt,
+  FALLBACK_SYSTEM_PROMPT,
+  formatDeviceInfo,
+  parseRestrictedDeviceIds,
+  type DeviceInfo,
+  type SystemPromptConfig,
+} from "../config/system-prompts";
+
+describe("system-prompts", () => {
+  describe("formatDeviceInfo", () => {
+    it("should format physical devices with infrared remotes", () => {
+      const apiResponse = {
+        statusCode: 100,
+        message: "success",
+        body: {
+          deviceList: [
+            {
+              deviceId: "ABC123",
+              deviceName: "リビング温湿度計",
+              deviceType: "MeterPlus",
+              enableCloudService: true,
+              hubDeviceId: "HUB001",
+            },
+          ],
+          infraredRemoteList: [
+            {
+              deviceId: "IR-001",
+              deviceName: "エアコン",
+              remoteType: "Air Conditioner",
+              hubDeviceId: "HUB001",
+            },
+          ],
+        },
+      };
+
+      const result = formatDeviceInfo(apiResponse, []);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        deviceId: "ABC123",
+        deviceName: "リビング温湿度計",
+        deviceType: "MeterPlus",
+        isRestricted: false,
+      });
+      expect(result[1]).toEqual({
+        deviceId: "IR-001",
+        deviceName: "エアコン",
+        deviceType: "Air Conditioner",
+        isRestricted: false,
+      });
+    });
+
+    it("should mark restricted devices", () => {
+      const apiResponse = {
+        statusCode: 100,
+        message: "success",
+        body: {
+          deviceList: [
+            {
+              deviceId: "DEV-1",
+              deviceName: "ハブミニ",
+              deviceType: "Hub Mini",
+              enableCloudService: true,
+              hubDeviceId: "",
+            },
+          ],
+          infraredRemoteList: [
+            {
+              deviceId: "IR-TV",
+              deviceName: "テレビ",
+              remoteType: "TV",
+              hubDeviceId: "DEV-1",
+            },
+          ],
+        },
+      };
+
+      const result = formatDeviceInfo(apiResponse, ["IR-TV"]);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].isRestricted).toBe(false);
+      expect(result[1].isRestricted).toBe(true);
+    });
+
+    it("should handle empty device lists", () => {
+      const apiResponse = {
+        statusCode: 100,
+        message: "success",
+        body: {
+          deviceList: [],
+          infraredRemoteList: [],
+        },
+      };
+
+      const result = formatDeviceInfo(apiResponse, []);
+      expect(result).toHaveLength(0);
+    });
+
+    it("should handle missing body gracefully", () => {
+      const apiResponse = { statusCode: 100, message: "success" };
+      const result = formatDeviceInfo(apiResponse, []);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("generateSystemPrompt", () => {
+    const sampleDevices: DeviceInfo[] = [
+      {
+        deviceId: "HUB-001",
+        deviceName: "ハブミニ",
+        deviceType: "Hub Mini",
+        isRestricted: false,
+      },
+      {
+        deviceId: "METER-001",
+        deviceName: "温湿度計",
+        deviceType: "MeterPlus",
+        isRestricted: false,
+      },
+      {
+        deviceId: "IR-AC",
+        deviceName: "エアコン",
+        deviceType: "Air Conditioner",
+        isRestricted: true,
+      },
+    ];
+
+    it("should include device list in the prompt", () => {
+      const prompt = generateSystemPrompt(sampleDevices);
+
+      expect(prompt).toContain("ハブミニ");
+      expect(prompt).toContain("HUB-001");
+      expect(prompt).toContain("Hub Mini");
+      expect(prompt).toContain("温湿度計");
+      expect(prompt).toContain("METER-001");
+    });
+
+    it("should mark restricted devices with warning", () => {
+      const prompt = generateSystemPrompt(sampleDevices);
+
+      expect(prompt).toContain("操作禁止");
+      expect(prompt).toContain("エアコン");
+    });
+
+    it("should include safety instructions", () => {
+      const prompt = generateSystemPrompt(sampleDevices);
+
+      expect(prompt).toContain("スマートホーム制御アシスタント");
+      expect(prompt).toContain("ツール");
+      expect(prompt).toContain("危険");
+    });
+
+    it("should include custom instructions when provided", () => {
+      const config: SystemPromptConfig = {
+        customInstructions: "深夜帯（23:00-06:00）は操作を控えてください",
+      };
+
+      const prompt = generateSystemPrompt(sampleDevices, config);
+
+      expect(prompt).toContain("深夜帯（23:00-06:00）は操作を控えてください");
+    });
+
+    it("should handle empty device list with informative message", () => {
+      const prompt = generateSystemPrompt([]);
+
+      expect(prompt).toContain("スマートホーム制御アシスタント");
+      expect(prompt).toContain("get_devices");
+    });
+
+    it("should set temperature guidance for tool calls", () => {
+      const prompt = generateSystemPrompt(sampleDevices);
+
+      expect(prompt).toContain("自然言語で説明");
+    });
+  });
+
+  describe("FALLBACK_SYSTEM_PROMPT", () => {
+    it("should provide basic instructions without device info", () => {
+      expect(FALLBACK_SYSTEM_PROMPT).toContain(
+        "スマートホーム制御アシスタント",
+      );
+      expect(FALLBACK_SYSTEM_PROMPT).toContain("get_devices");
+      expect(FALLBACK_SYSTEM_PROMPT).not.toContain("ID:");
+    });
+  });
+
+  describe("parseRestrictedDeviceIds", () => {
+    it("should parse comma-separated device IDs", () => {
+      const result = parseRestrictedDeviceIds("DEV-1,DEV-2,DEV-3");
+      expect(result).toEqual(["DEV-1", "DEV-2", "DEV-3"]);
+    });
+
+    it("should trim whitespace from IDs", () => {
+      const result = parseRestrictedDeviceIds(" DEV-1 , DEV-2 , DEV-3 ");
+      expect(result).toEqual(["DEV-1", "DEV-2", "DEV-3"]);
+    });
+
+    it("should return empty array for empty string", () => {
+      const result = parseRestrictedDeviceIds("");
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array for undefined", () => {
+      const result = parseRestrictedDeviceIds(undefined);
+      expect(result).toEqual([]);
+    });
+
+    it("should filter out empty entries", () => {
+      const result = parseRestrictedDeviceIds("DEV-1,,DEV-2,");
+      expect(result).toEqual(["DEV-1", "DEV-2"]);
+    });
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,16 +1,17 @@
-import Fastify, { FastifyInstance } from 'fastify';
-import { SwitchBotClient } from '@llm-switchbot/switchbot-adapter';
-import { ChatOrchestrator } from './orchestrator/chat-orchestrator';
-import cors from '@fastify/cors';
-import env from '@fastify/env';
-import { LLMFactory } from '@llm-switchbot/harmony-tools';
-import * as dotenv from 'dotenv';
+import Fastify, { FastifyInstance } from "fastify";
+import { SwitchBotClient } from "@llm-switchbot/switchbot-adapter";
+import { ChatOrchestrator } from "./orchestrator/chat-orchestrator";
+import cors from "@fastify/cors";
+import env from "@fastify/env";
+import { LLMFactory } from "@llm-switchbot/harmony-tools";
+import * as dotenv from "dotenv";
+import { parseRestrictedDeviceIds } from "./config/system-prompts";
 
 // 環境変数を直接読み込み（プロジェクトルートから）
-dotenv.config({ path: '../../.env' });
+dotenv.config({ path: "../../.env" });
 
 // Extend FastifyInstance with our services
-declare module 'fastify' {
+declare module "fastify" {
   interface FastifyInstance {
     switchBotClient: SwitchBotClient;
     chatOrchestrator: ChatOrchestrator;
@@ -28,106 +29,118 @@ declare module 'fastify' {
 }
 
 const envSchema = {
-  type: 'object',
+  type: "object",
   properties: {
-    PORT: { type: 'number', default: 3001 },
-    HOST: { type: 'string', default: '0.0.0.0' },
-    SWITCHBOT_TOKEN: { type: 'string' },
-    SWITCHBOT_SECRET: { type: 'string' },
-    SWITCHBOT_WEBHOOK_VERIFY_TOKEN: { type: 'string' },
-    SWITCHBOT_WEBHOOK_SECRET: { type: 'string' },
-    LLM_PROVIDER: { type: 'string', default: 'openai' },
-    OPENAI_API_KEY: { type: 'string', default: '' },
-    OPENAI_BASE_URL: { type: 'string', default: 'https://api.openai.com/v1' },
-    OPENAI_MODEL: { type: 'string', default: 'gpt-4o-mini' },
-    LLM_BASE_URL: { type: 'string', default: 'http://localhost:8000' },
-    LLM_MODEL: { type: 'string', default: 'gpt-oss-20b' },
-    LLM_API_KEY: { type: 'string', default: '' },
-    OLLAMA_BASE_URL: { type: 'string', default: 'http://localhost:11434' },
-    OLLAMA_MODEL: { type: 'string', default: 'gpt-oss-20b' }
+    PORT: { type: "number", default: 3001 },
+    HOST: { type: "string", default: "0.0.0.0" },
+    SWITCHBOT_TOKEN: { type: "string" },
+    SWITCHBOT_SECRET: { type: "string" },
+    SWITCHBOT_WEBHOOK_VERIFY_TOKEN: { type: "string" },
+    SWITCHBOT_WEBHOOK_SECRET: { type: "string" },
+    LLM_PROVIDER: { type: "string", default: "openai" },
+    OPENAI_API_KEY: { type: "string", default: "" },
+    OPENAI_BASE_URL: { type: "string", default: "https://api.openai.com/v1" },
+    OPENAI_MODEL: { type: "string", default: "gpt-4o-mini" },
+    LLM_BASE_URL: { type: "string", default: "http://localhost:8000" },
+    LLM_MODEL: { type: "string", default: "gpt-oss-20b" },
+    LLM_API_KEY: { type: "string", default: "" },
+    OLLAMA_BASE_URL: { type: "string", default: "http://localhost:11434" },
+    OLLAMA_MODEL: { type: "string", default: "gpt-oss-20b" },
+    RESTRICTED_DEVICES: { type: "string", default: "" },
+    SYSTEM_PROMPT_CUSTOM_INSTRUCTIONS: { type: "string", default: "" },
   },
-  required: []
+  required: [],
 };
 
 export async function build(opts = {}) {
   const fastify: FastifyInstance = Fastify({
     logger: {
-      level: 'info',
+      level: "info",
       transport: {
-        target: 'pino-pretty'
-      }
+        target: "pino-pretty",
+      },
     },
-    ...opts
+    ...opts,
   });
 
   // Register plugins
   fastify.register(cors, {
     origin: true,
-    credentials: true
+    credentials: true,
   });
 
   fastify.register(env, {
     schema: envSchema,
-    dotenv: true // 環境変数ファイルを読み込む
+    dotenv: true, // 環境変数ファイルを読み込む
   });
 
-    // Health check route
-  fastify.get('/health', async () => {
+  // Health check route
+  fastify.get("/health", async () => {
     return {
-      status: 'ok',
-      timestamp: new Date().toISOString()
+      status: "ok",
+      timestamp: new Date().toISOString(),
     };
   });
 
   // Initialize services (before ready)
   const switchBotClient = new SwitchBotClient(
-    process.env.SWITCHBOT_TOKEN || 'demo-token',
-    process.env.SWITCHBOT_SECRET || 'demo-secret'
+    process.env.SWITCHBOT_TOKEN || "demo-token",
+    process.env.SWITCHBOT_SECRET || "demo-secret",
   );
 
   // Initialize LLM adapter
   let llmAdapter = null;
   try {
-    if (process.env.LLM_PROVIDER === 'openai' && process.env.OPENAI_API_KEY) {
-      llmAdapter = LLMFactory.create('openai', {
+    if (process.env.LLM_PROVIDER === "openai" && process.env.OPENAI_API_KEY) {
+      llmAdapter = LLMFactory.create("openai", {
         apiKey: process.env.OPENAI_API_KEY,
-        baseUrl: process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1',
-        model: process.env.OPENAI_MODEL || 'gpt-4o-mini'
+        baseUrl: process.env.OPENAI_BASE_URL || "https://api.openai.com/v1",
+        model: process.env.OPENAI_MODEL || "gpt-4o-mini",
       });
-      fastify.log.info('OpenAI LLM adapter initialized');
-    } else if (process.env.LLM_PROVIDER === 'ollama') {
-      llmAdapter = LLMFactory.create('ollama', {
-        baseUrl: process.env.OLLAMA_BASE_URL || 'http://localhost:11434',
-        model: process.env.OLLAMA_MODEL || 'gpt-oss-20b'
+      fastify.log.info("OpenAI LLM adapter initialized");
+    } else if (process.env.LLM_PROVIDER === "ollama") {
+      llmAdapter = LLMFactory.create("ollama", {
+        baseUrl: process.env.OLLAMA_BASE_URL || "http://localhost:11434",
+        model: process.env.OLLAMA_MODEL || "gpt-oss-20b",
       });
-      fastify.log.info('Ollama LLM adapter initialized');
-    } else if (process.env.LLM_PROVIDER === 'gpt-oss') {
-      llmAdapter = LLMFactory.create('gpt-oss', {
-        baseUrl: process.env.LLM_BASE_URL || 'http://localhost:8000',
-        model: process.env.LLM_MODEL || 'gpt-oss-20b'
+      fastify.log.info("Ollama LLM adapter initialized");
+    } else if (process.env.LLM_PROVIDER === "gpt-oss") {
+      llmAdapter = LLMFactory.create("gpt-oss", {
+        baseUrl: process.env.LLM_BASE_URL || "http://localhost:8000",
+        model: process.env.LLM_MODEL || "gpt-oss-20b",
       });
-      fastify.log.info('gpt-oss LLM adapter initialized');
+      fastify.log.info("gpt-oss LLM adapter initialized");
     } else {
-      fastify.log.info('No LLM adapter configured, using demo mode');
+      fastify.log.info("No LLM adapter configured, using demo mode");
     }
   } catch (error) {
-    fastify.log.error('Failed to initialize LLM adapter:', error as any);
+    fastify.log.error("Failed to initialize LLM adapter:", error as any);
   }
 
-  // Initialize ChatOrchestrator
-  const chatOrchestrator = new ChatOrchestrator(switchBotClient, llmAdapter || undefined);
+  // Initialize ChatOrchestrator with dynamic system prompt config
+  const restrictedDeviceIds = parseRestrictedDeviceIds(
+    process.env.RESTRICTED_DEVICES,
+  );
+  const chatOrchestrator = new ChatOrchestrator(
+    switchBotClient,
+    llmAdapter || undefined,
+    {
+      restrictedDeviceIds,
+      customInstructions: process.env.SYSTEM_PROMPT_CUSTOM_INSTRUCTIONS,
+    },
+  );
 
   // Add services to fastify instance (before ready)
-  fastify.decorate('switchBotClient', switchBotClient);
-  fastify.decorate('chatOrchestrator', chatOrchestrator);
+  fastify.decorate("switchBotClient", switchBotClient);
+  fastify.decorate("chatOrchestrator", chatOrchestrator);
 
   // Register route plugins (before ready)
-  fastify.register(require('./routes/switchbot'), { prefix: '/api/switchbot' });
-  fastify.register(require('./routes/chat'), { prefix: '/api' });
-  fastify.register(require('./routes/webhooks'), { prefix: '/api/webhooks' });
-  fastify.register(require('./routes/automation'), { prefix: '/api' });
-  fastify.register(require('./routes/debug'), { prefix: '/api' });
-  fastify.register(require('./routes/automation-workflow'), { prefix: '/api' });
+  fastify.register(require("./routes/switchbot"), { prefix: "/api/switchbot" });
+  fastify.register(require("./routes/chat"), { prefix: "/api" });
+  fastify.register(require("./routes/webhooks"), { prefix: "/api/webhooks" });
+  fastify.register(require("./routes/automation"), { prefix: "/api" });
+  fastify.register(require("./routes/debug"), { prefix: "/api" });
+  fastify.register(require("./routes/automation-workflow"), { prefix: "/api" });
 
   // Wait for environment variables to be loaded
   await fastify.ready();

--- a/apps/api/src/config/system-prompts.ts
+++ b/apps/api/src/config/system-prompts.ts
@@ -1,0 +1,137 @@
+export interface DeviceInfo {
+  deviceId: string;
+  deviceName: string;
+  deviceType: string;
+  isRestricted: boolean;
+}
+
+export interface SystemPromptConfig {
+  restrictedDeviceIds?: string[];
+  customInstructions?: string;
+}
+
+/**
+ * SwitchBot API レスポンスからデバイス情報を抽出し、制限情報を付加する。
+ * deviceList（物理デバイス）と infraredRemoteList（赤外線リモコン）の両方を統合する。
+ */
+export function formatDeviceInfo(
+  apiResponse: Record<string, unknown>,
+  restrictedIds: string[],
+): DeviceInfo[] {
+  const body = apiResponse.body as
+    | {
+        deviceList?: Array<{
+          deviceId: string;
+          deviceName: string;
+          deviceType: string;
+        }>;
+        infraredRemoteList?: Array<{
+          deviceId: string;
+          deviceName: string;
+          remoteType: string;
+        }>;
+      }
+    | undefined;
+
+  if (!body) return [];
+
+  const restricted = new Set(restrictedIds);
+  const devices: DeviceInfo[] = [];
+
+  for (const d of body.deviceList ?? []) {
+    devices.push({
+      deviceId: d.deviceId,
+      deviceName: d.deviceName,
+      deviceType: d.deviceType,
+      isRestricted: restricted.has(d.deviceId),
+    });
+  }
+
+  for (const ir of body.infraredRemoteList ?? []) {
+    devices.push({
+      deviceId: ir.deviceId,
+      deviceName: ir.deviceName,
+      deviceType: ir.remoteType,
+      isRestricted: restricted.has(ir.deviceId),
+    });
+  }
+
+  return devices;
+}
+
+/**
+ * デバイス情報と設定からシステムプロンプトを動的に生成する。
+ */
+export function generateSystemPrompt(
+  devices: DeviceInfo[],
+  config?: SystemPromptConfig,
+): string {
+  if (devices.length === 0) {
+    return `あなたはスマートホーム制御アシスタントです。SwitchBot APIを使用してデバイスを操作できます。
+
+現在デバイス情報を保持していません。get_devicesツールを使用して利用可能なデバイスを確認してください。
+
+**重要な指示:**
+1. まずget_devicesで利用可能なデバイスを確認してください
+2. 明確にデバイス操作を求められた場合のみツールを使用してください
+3. ツール実行後は、取得した結果を分かりやすく自然言語で説明してください
+4. 危険な操作（解錠など）はユーザーに確認を取ってから実行してください`;
+  }
+
+  const restrictedDevices = devices.filter((d) => d.isRestricted);
+
+  const deviceLines = devices
+    .map((d) => {
+      const tag = d.isRestricted ? " (操作禁止)" : "";
+      return `- ${d.deviceName} (ID: ${d.deviceId}) - ${d.deviceType}${tag}`;
+    })
+    .join("\n");
+
+  const restrictedWarning =
+    restrictedDevices.length > 0
+      ? `\n以下のデバイスの操作は禁止されています。絶対に操作しないでください: ${restrictedDevices.map((d) => d.deviceName).join("、")}`
+      : "";
+
+  const customBlock = config?.customInstructions
+    ? `\n\n**追加指示:**\n${config.customInstructions}`
+    : "";
+
+  return `あなたはスマートホーム制御アシスタントです。SwitchBot APIを使用してデバイスを操作できます。
+
+**利用可能なデバイス:**
+${deviceLines}
+${restrictedWarning}
+**重要な指示:**
+1. デバイスIDがわかっている場合、get_devicesを呼ぶ必要はありません
+2. 明確にデバイス操作を求められた場合のみツールを使用してください
+3. ツール実行後は、取得した結果を分かりやすく自然言語で説明してください
+4. 温湿度計の結果では、温度・湿度・バッテリー状態と快適度を説明してください
+5. 危険な操作（解錠など）はユーザーに確認を取ってから実行してください${customBlock}`;
+}
+
+/**
+ * 環境変数文字列からカンマ区切りのデバイスIDリストをパースする。
+ */
+export function parseRestrictedDeviceIds(
+  envValue: string | undefined,
+): string[] {
+  if (!envValue) return [];
+  return envValue
+    .split(",")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+}
+
+/**
+ * デバイス情報取得に失敗した場合のフォールバックプロンプト。
+ * LLMにget_devicesツールの使用を促す。
+ */
+export const FALLBACK_SYSTEM_PROMPT = `あなたはスマートホーム制御アシスタントです。SwitchBot APIを使用してデバイスを操作できます。
+
+デバイス情報の取得に失敗しました。get_devicesツールを使用して利用可能なデバイスを確認してください。
+
+**重要な指示:**
+1. まずget_devicesで利用可能なデバイスを確認してください
+2. 明確にデバイス操作を求められた場合のみツールを使用してください
+3. ツール実行後は、取得した結果を分かりやすく自然言語で説明してください
+4. 危険な操作（解錠など）はユーザーに確認を取ってから実行してください`;

--- a/apps/api/src/orchestrator/chat-orchestrator.ts
+++ b/apps/api/src/orchestrator/chat-orchestrator.ts
@@ -1,21 +1,27 @@
-import { SwitchBotClient } from '@llm-switchbot/switchbot-adapter';
-import { 
-  harmonyToolsSchema, 
-  validateToolCall, 
+import { SwitchBotClient } from "@llm-switchbot/switchbot-adapter";
+import {
+  harmonyToolsSchema,
+  validateToolCall,
   createToolResponse,
   HARMONY_TOOLS,
   type HarmonyToolsSchema,
   type ToolResponse,
   LLMFactory,
   LLMAdapter,
-  LLMRequest
-} from '@llm-switchbot/harmony-tools';
-import { AutomationProposalService } from '../services/automation-proposal';
-import { SceneLearningService } from '../services/scene-learning';
+  LLMRequest,
+} from "@llm-switchbot/harmony-tools";
+import { AutomationProposalService } from "../services/automation-proposal";
+import { SceneLearningService } from "../services/scene-learning";
+import {
+  generateSystemPrompt,
+  formatDeviceInfo,
+  FALLBACK_SYSTEM_PROMPT,
+  type SystemPromptConfig,
+} from "../config/system-prompts";
 
 export interface ToolCall {
   id: string;
-  type: 'function';
+  type: "function";
   function: {
     name: string;
     arguments: string;
@@ -23,13 +29,13 @@ export interface ToolCall {
 }
 
 export interface ChatMessage {
-  role: 'user' | 'assistant' | 'system';
+  role: "user" | "assistant" | "system";
   content: string;
   tool_calls?: ToolCall[];
 }
 
 export interface ChatResponse {
-  role: 'assistant';
+  role: "assistant";
   content: string;
   tool_calls?: ToolCall[];
 }
@@ -39,6 +45,12 @@ export interface ChatProcessResult {
   toolResults: ToolResponse[];
 }
 
+export interface ChatOrchestratorOptions extends SystemPromptConfig {
+  promptCacheTtlMs?: number;
+}
+
+const DEFAULT_PROMPT_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
 /**
  * チャット処理とツール呼び出しを統合管理するオーケストレーター
  */
@@ -47,10 +59,18 @@ export class ChatOrchestrator {
   private llmAdapter: LLMAdapter | null = null;
   private automationService: AutomationProposalService;
   private sceneLearningService: SceneLearningService;
+  private options: ChatOrchestratorOptions;
+  private cachedSystemPrompt: string | null = null;
+  private cachedAt: number = 0;
 
-  constructor(switchBotClient: SwitchBotClient, llmAdapter?: LLMAdapter) {
+  constructor(
+    switchBotClient: SwitchBotClient,
+    llmAdapter?: LLMAdapter,
+    options?: ChatOrchestratorOptions,
+  ) {
     this.switchBotClient = switchBotClient;
     this.llmAdapter = llmAdapter || null;
+    this.options = options ?? {};
     this.automationService = new AutomationProposalService(switchBotClient);
     this.sceneLearningService = new SceneLearningService(switchBotClient);
   }
@@ -67,7 +87,7 @@ export class ChatOrchestrator {
    */
   async processToolCall(toolCall: ToolCall): Promise<ToolResponse> {
     const startTime = Date.now();
-    
+
     try {
       // 引数のパース
       let parsedArgs: any;
@@ -77,46 +97,48 @@ export class ChatOrchestrator {
         return createToolResponse(
           toolCall.function.name,
           null,
-          'error',
-          `Invalid JSON arguments: ${error instanceof Error ? error.message : 'Unknown error'}`,
-          Date.now() - startTime
+          "error",
+          `Invalid JSON arguments: ${error instanceof Error ? error.message : "Unknown error"}`,
+          Date.now() - startTime,
         );
       }
 
       // ツール呼び出しの妥当性検証
       const validation = validateToolCall({
         name: toolCall.function.name,
-        arguments: parsedArgs
+        arguments: parsedArgs,
       });
 
       if (!validation.isValid) {
         return createToolResponse(
           toolCall.function.name,
           null,
-          'error',
-          validation.errors.join(', '),
-          Date.now() - startTime
+          "error",
+          validation.errors.join(", "),
+          Date.now() - startTime,
         );
       }
 
       // ツール実行
-      const result = await this.executeToolCall(toolCall.function.name, parsedArgs);
-      
+      const result = await this.executeToolCall(
+        toolCall.function.name,
+        parsedArgs,
+      );
+
       return createToolResponse(
         toolCall.function.name,
         result,
-        'success',
+        "success",
         undefined,
-        Date.now() - startTime
+        Date.now() - startTime,
       );
-
     } catch (error) {
       return createToolResponse(
         toolCall.function.name,
         null,
-        'error',
-        error instanceof Error ? error.message : 'Unknown error occurred',
-        Date.now() - startTime
+        "error",
+        error instanceof Error ? error.message : "Unknown error occurred",
+        Date.now() - startTime,
       );
     }
   }
@@ -136,7 +158,7 @@ export class ChatOrchestrator {
         return await this.switchBotClient.sendCommand(
           args.deviceId,
           args.command,
-          args.parameter
+          args.parameter,
         );
 
       case HARMONY_TOOLS.GET_SCENES:
@@ -151,53 +173,61 @@ export class ChatOrchestrator {
   }
 
   /**
+   * SwitchBot API からデバイス情報を取得し、動的にシステムメッセージを生成する。
+   * 結果は設定可能な TTL でキャッシュされ、API コールを最小化する。
+   */
+  async generateSystemMessage(): Promise<{ role: "system"; content: string }> {
+    const ttl = this.options.promptCacheTtlMs ?? DEFAULT_PROMPT_CACHE_TTL_MS;
+
+    if (this.cachedSystemPrompt && Date.now() - this.cachedAt < ttl) {
+      return { role: "system" as const, content: this.cachedSystemPrompt };
+    }
+
+    try {
+      const apiResponse = await this.switchBotClient.getDevices();
+      const devices = formatDeviceInfo(
+        apiResponse,
+        this.options.restrictedDeviceIds ?? [],
+      );
+      const prompt = generateSystemPrompt(devices, this.options);
+      this.cachedSystemPrompt = prompt;
+      this.cachedAt = Date.now();
+      return { role: "system" as const, content: prompt };
+    } catch (_error) {
+      return { role: "system" as const, content: FALLBACK_SYSTEM_PROMPT };
+    }
+  }
+
+  /**
    * チャットメッセージを処理し、必要に応じてツール呼び出しを実行
    */
   async processChat(
-    messages: ChatMessage[], 
-    enableTools: boolean = false
+    messages: ChatMessage[],
+    enableTools: boolean = false,
   ): Promise<ChatProcessResult> {
     const toolResults: ToolResponse[] = [];
 
-    // LLMアダプターが利用可能な場合は実際のLLMを使用
     if (this.llmAdapter) {
       try {
-        // システムメッセージを追加してデバイス情報を提供
-        const systemMessage = {
-          role: 'system' as const,
-          content: `あなたはスマートホーム制御アシスタントです。以下のデバイスが利用可能です：
+        const systemMessage = await this.generateSystemMessage();
 
-**利用可能なデバイス:**
-- ハブミニ (ID: E1750C44657C) - Hub Mini
-- 温湿度計 (ID: F66854E650BE) - MeterPlus - 温度・湿度測定
-- アップル (ID: 02-202208281754-46662932) - TVリモート (操作禁止)
-- エアコン (ID: 02-202212241621-96856893) - エアコンリモート (操作禁止)
-
-**重要な指示:**
-1. エアコンとテレビ（アップル）の操作は絶対に行わないでください
-2. 温湿度計のデバッグのみ実行してください
-3. デバイスIDがわかっている場合、get_devicesを呼ぶ必要はありません
-4. 温湿度計の状態確認は get_device_status (deviceId: F66854E650BE) を使用
-5. 明確にデバイス操作を求められた場合のみツールを使用してください
-6. ツール実行後は、取得した結果を分かりやすく自然言語で説明してください
-7. 温湿度計の結果では、温度・湿度・バッテリー状態と快適度を説明してください`
-        };
-
-        const messagesWithSystem = [systemMessage, ...messages.map(msg => ({
-          role: msg.role,
-          content: msg.content
-        }))];
+        const messagesWithSystem = [
+          systemMessage,
+          ...messages.map((msg) => ({
+            role: msg.role,
+            content: msg.content,
+          })),
+        ];
 
         const llmRequest: LLMRequest = {
           messages: messagesWithSystem,
           tools: enableTools ? harmonyToolsSchema.tools : undefined,
           temperature: 0.7,
-          max_tokens: 1000
+          max_tokens: 1000,
         };
 
         const llmResponse = await this.llmAdapter.chat(llmRequest);
-        
-        // ツール呼び出しの処理
+
         if (llmResponse.tool_calls && llmResponse.tool_calls.length > 0) {
           for (const toolCall of llmResponse.tool_calls) {
             const toolResult = await this.processToolCall(toolCall);
@@ -206,24 +236,22 @@ export class ChatOrchestrator {
         }
 
         const response: ChatResponse = {
-          role: 'assistant',
+          role: "assistant",
           content: llmResponse.content,
-          tool_calls: llmResponse.tool_calls
+          tool_calls: llmResponse.tool_calls,
         };
 
         return {
           response,
-          toolResults
+          toolResults,
         };
-
       } catch (error) {
-        console.error('LLM処理エラー:', error);
-        // フォールバック: デモモード
+        // eslint-disable-next-line no-console -- pino logger not available in orchestrator scope; to be replaced in logging task
+        console.error("LLM処理エラー:", error);
         return this.processChatDemo(messages, enableTools);
       }
     }
 
-    // LLMアダプターが利用できない場合はデモモード
     return this.processChatDemo(messages, enableTools);
   }
 
@@ -231,15 +259,15 @@ export class ChatOrchestrator {
    * デモモードでのチャット処理
    */
   private async processChatDemo(
-    messages: ChatMessage[], 
-    enableTools: boolean = false
+    messages: ChatMessage[],
+    enableTools: boolean = false,
   ): Promise<ChatProcessResult> {
     const toolResults: ToolResponse[] = [];
 
     if (enableTools && this.shouldUseTool(messages)) {
       const lastMessage = messages[messages.length - 1];
       const toolCall = this.generateMockToolCall(lastMessage.content);
-      
+
       if (toolCall) {
         const toolResult = await this.processToolCall(toolCall);
         toolResults.push(toolResult);
@@ -247,13 +275,13 @@ export class ChatOrchestrator {
     }
 
     const response: ChatResponse = {
-      role: 'assistant',
-      content: this.generateMockResponse(messages, toolResults)
+      role: "assistant",
+      content: this.generateMockResponse(messages, toolResults),
     };
 
     return {
       response,
-      toolResults
+      toolResults,
     };
   }
 
@@ -263,13 +291,15 @@ export class ChatOrchestrator {
   private shouldUseTool(messages: ChatMessage[]): boolean {
     const lastMessage = messages[messages.length - 1];
     const content = lastMessage.content.toLowerCase();
-    
-    return content.includes('デバイス') || 
-           content.includes('一覧') || 
-           content.includes('状態') ||
-           content.includes('つけて') ||
-           content.includes('消して') ||
-           content.includes('シーン');
+
+    return (
+      content.includes("デバイス") ||
+      content.includes("一覧") ||
+      content.includes("状態") ||
+      content.includes("つけて") ||
+      content.includes("消して") ||
+      content.includes("シーン")
+    );
   }
 
   /**
@@ -277,29 +307,29 @@ export class ChatOrchestrator {
    */
   private generateMockToolCall(content: string): ToolCall | null {
     const lowerContent = content.toLowerCase();
-    
-    if (lowerContent.includes('デバイス') || lowerContent.includes('一覧')) {
+
+    if (lowerContent.includes("デバイス") || lowerContent.includes("一覧")) {
       return {
         id: `call-${Date.now()}`,
-        type: 'function',
+        type: "function",
         function: {
-          name: 'get_devices',
-          arguments: '{}'
-        }
+          name: "get_devices",
+          arguments: "{}",
+        },
       };
     }
-    
-    if (lowerContent.includes('つけて') || lowerContent.includes('オン')) {
+
+    if (lowerContent.includes("つけて") || lowerContent.includes("オン")) {
       return {
         id: `call-${Date.now()}`,
-        type: 'function',
+        type: "function",
         function: {
-          name: 'send_command',
+          name: "send_command",
           arguments: JSON.stringify({
-            deviceId: 'demo-device-1',
-            command: 'turnOn'
-          })
-        }
+            deviceId: "demo-device-1",
+            command: "turnOn",
+          }),
+        },
       };
     }
 
@@ -309,25 +339,28 @@ export class ChatOrchestrator {
   /**
    * モック応答を生成（デモ用）
    */
-  private generateMockResponse(messages: ChatMessage[], toolResults: ToolResponse[]): string {
+  private generateMockResponse(
+    messages: ChatMessage[],
+    toolResults: ToolResponse[],
+  ): string {
     if (toolResults.length === 0) {
-      return 'デモモードです。「デバイス一覧を教えて」「エアコンをつけて」などと話しかけてツール機能をお試しください。';
+      return "デモモードです。「デバイス一覧を教えて」「エアコンをつけて」などと話しかけてツール機能をお試しください。";
     }
 
     const lastResult = toolResults[toolResults.length - 1];
-    
-    if (lastResult.tool_name === 'get_devices') {
-      if (lastResult.status === 'success') {
+
+    if (lastResult.tool_name === "get_devices") {
+      if (lastResult.status === "success") {
         const deviceCount = lastResult.result?.body?.deviceList?.length || 0;
         return `デバイス一覧を取得しました。現在${deviceCount}個のデバイスが利用可能です。`;
       } else {
         return `デバイス一覧の取得中にエラーが発生しました: ${lastResult.error_message}`;
       }
     }
-    
-    if (lastResult.tool_name === 'send_command') {
-      if (lastResult.status === 'success') {
-        return 'デバイスコマンドを実行しました。操作が完了しています。';
+
+    if (lastResult.tool_name === "send_command") {
+      if (lastResult.status === "success") {
+        return "デバイスコマンドを実行しました。操作が完了しています。";
       } else {
         return `デバイス操作中にエラーが発生しました: ${lastResult.error_message}`;
       }

--- a/apps/api/src/orchestrator/chat-orchestrator.ts
+++ b/apps/api/src/orchestrator/chat-orchestrator.ts
@@ -6,7 +6,6 @@ import {
   HARMONY_TOOLS,
   type HarmonyToolsSchema,
   type ToolResponse,
-  LLMFactory,
   LLMAdapter,
   LLMRequest,
 } from "@llm-switchbot/harmony-tools";
@@ -194,6 +193,7 @@ export class ChatOrchestrator {
       this.cachedAt = Date.now();
       return { role: "system" as const, content: prompt };
     } catch (_error) {
+      // TODO: pino ロガーをオーケストレータースコープに導入後、ここでエラーを記録する
       return { role: "system" as const, content: FALLBACK_SYSTEM_PROMPT };
     }
   }

--- a/doc/plan.md
+++ b/doc/plan.md
@@ -174,7 +174,11 @@ POST /api/scenes/learn/candidates          // シーン候補生成
     {
       "name": "get_devices",
       "description": "List devices",
-      "input_schema": { "type": "object", "properties": {}, "additionalProperties": false }
+      "input_schema": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      }
     },
     {
       "name": "get_status",
@@ -204,7 +208,11 @@ POST /api/scenes/learn/candidates          // シーン候補生成
     {
       "name": "get_scenes",
       "description": "List scenes",
-      "input_schema": { "type": "object", "properties": {}, "additionalProperties": false }
+      "input_schema": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      }
     },
     {
       "name": "exec_scene",
@@ -269,14 +277,12 @@ POST /api/scenes/learn/candidates          // シーン候補生成
 
 ##### 🔧 対応予定
 
-- **固定プロンプトの問題**: ChatOrchestrator のシステムメッセージがハードコード
-  - デバイスID が固定（F66854E650BE 等）、デバイス一覧が静的、設定変更不可
-  - 実装アプローチ:
-    - `generateSystemMessage()` メソッド: SwitchBot API から動的デバイス情報を取得
-    - プロンプトテンプレートファイル化: `config/system-prompts.ts` の作成
-    - 環境変数対応: `SYSTEM_PROMPT_TEMPLATE`, `RESTRICTED_DEVICES` 等の追加
-    - フォールバック: デバイス取得失敗時は基本プロンプトを使用
-  - 優先度: Day 6以降
+- ~~**固定プロンプトの問題**: ChatOrchestrator のシステムメッセージがハードコード~~ → **解決済み**
+  - `generateSystemMessage()` で SwitchBot API から動的デバイス情報を取得
+  - `apps/api/src/config/system-prompts.ts` にプロンプトテンプレート外部化
+  - 環境変数 `RESTRICTED_DEVICES`, `SYSTEM_PROMPT_CUSTOM_INSTRUCTIONS` で設定可能
+  - デバイス取得失敗時は `FALLBACK_SYSTEM_PROMPT` にフォールバック
+  - プロンプトキャッシュ（デフォルト10分TTL）でAPI呼び出し最小化
 
 - **ESLint設定の完全修正**: API アプリの ESLint TypeScript 設定が一時的にスキップ状態
   - 対策: TypeScript ESLint プラグインの依存関係修正
@@ -317,10 +323,12 @@ POST /api/scenes/learn/candidates          // シーン候補生成
 本計画は `doc/spec.md` を技術的・戦術的に分解したものです。
 
 #### 基盤・インフラ
+
 - [x] モノレポ雛形、CI（lint/test/build）
 - [x] Secrets 設計、環境変数雛形 (`.env.example`)
 
 #### SwitchBot API 連携
+
 - [x] SwitchBot 署名ユーティリティ + 単体テスト
 - [x] Webhook 仕様調査（署名・ヘッダ検証）
 - [x] `GET /devices` 実装 + 統合テスト
@@ -331,29 +339,34 @@ POST /api/scenes/learn/candidates          // シーン候補生成
 - [x] Webhook 受信・検証・イベント保存
 
 #### LLM 連携
+
 - [x] harmony ツール定義とツールディスパッチ
 - [x] マルチ LLM アダプター（OpenAI/Ollama/gpt-oss）
-- [ ] 動的システムプロンプト生成（デバイス情報の自動反映）
-- [ ] プロンプトテンプレート外部化（`config/system-prompts.ts`）
+- [x] 動的システムプロンプト生成（デバイス情報の自動反映）
+- [x] プロンプトテンプレート外部化（`config/system-prompts.ts`）
 
 #### ワークフローエンジン（自動化基盤）
+
 - [x] 自然言語ワークフローパーサー（LLM + フォールバック）
 - [x] 条件評価エンジン（time/temperature/humidity/device_state）
 - [x] 自動化スケジューラー（daily/weekly/interval/once）
 - [x] 自動化ワークフロー CRUD API
 
 #### 自動化・シーン学習
+
 - [x] 自動化提案（ルール + プロンプト）
 - [x] シーン学習（頻出操作の自動シーン化）
 - [x] パターン検出（順次/時間/頻出操作）
 
 #### フロントエンド
+
 - [x] チャット UI（メッセージ、デバイスカード、ツール可視化、結果リフィード）
 - [x] ワークフロー作成・管理 UI
 - [ ] リアルタイムイベント反映（SSE/WebSocket）
 - [ ] デバイスグルーピング/ルーム管理 UI
 
 #### 品質・運用
+
 - [ ] ESLint 設定の完全修正（API アプリ）
 - [ ] Web テストの修正（DeviceCard パラメータ期待値）
 - [ ] Web typecheck の修正（Jest/DOM 型定義）
@@ -361,10 +374,9 @@ POST /api/scenes/learn/candidates          // シーン候補生成
 - [ ] 操作監査ログの実装
 
 #### デモ・提出
+
 - [ ] デモシナリオ・README・動画
 
 ### 18. 参照リンク
 
 - `doc/spec.md` を参照。
-
-

--- a/env.example
+++ b/env.example
@@ -19,6 +19,12 @@ LLM_API_KEY=optional_api_key_here
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=gpt-oss-20b
 
+# System Prompt Configuration
+# Comma-separated device IDs to restrict from LLM control
+RESTRICTED_DEVICES=
+# Additional instructions appended to the system prompt (optional)
+SYSTEM_PROMPT_CUSTOM_INSTRUCTIONS=
+
 # Database
 DATABASE_URL=file:./dev.db
 


### PR DESCRIPTION
## Summary

- ChatOrchestratorのハードコードされたシステムプロンプトを、SwitchBot APIから動的にデバイス情報を取得して生成する方式に置き換え
- プロンプトテンプレートを `apps/api/src/config/system-prompts.ts` に外部化
- 環境変数 `RESTRICTED_DEVICES`（操作禁止デバイスのカンマ区切りID）と `SYSTEM_PROMPT_CUSTOM_INSTRUCTIONS`（追加指示）をサポート

## Changes

### 新規ファイル
- `apps/api/src/config/system-prompts.ts` — プロンプトテンプレート、`formatDeviceInfo()`, `generateSystemPrompt()`, `parseRestrictedDeviceIds()`, `FALLBACK_SYSTEM_PROMPT`
- `apps/api/src/__tests__/system-prompts.test.ts` — 16件のユニットテスト

### 変更ファイル
- `apps/api/src/orchestrator/chat-orchestrator.ts`
  - `generateSystemMessage()` メソッド追加（TTLベースキャッシュ付き）
  - `ChatOrchestratorOptions` インターフェース追加
  - `processChat()` からハードコードプロンプトを削除し、動的生成を使用
- `apps/api/src/__tests__/chat-orchestrator.test.ts` — 5件のテスト追加（動的プロンプト生成、制限デバイス、フォールバック、キャッシュ、TTL更新）
- `apps/api/src/app.ts` — `RESTRICTED_DEVICES` と `SYSTEM_PROMPT_CUSTOM_INSTRUCTIONS` の環境変数読み込み
- `env.example` — 新規環境変数の説明追加
- `doc/plan.md` — タスク完了マーク

## Design Decisions

1. **キャッシュ TTL**: デフォルト10分。`/devices` APIの負荷を最小化しつつ、デバイス追加時に合理的な時間で反映
2. **フォールバック**: API失敗時は `FALLBACK_SYSTEM_PROMPT` を返し、LLMに `get_devices` ツール使用を促す
3. **制限デバイス**: 環境変数でデバイスIDを指定し、プロンプト内で「操作禁止」としてマーク

## Test plan

- [x] `system-prompts.test.ts`: 16テスト全パス
- [x] `chat-orchestrator.test.ts`: 17テスト全パス
- [x] API全体テスト: 94テスト全パス
- [x] switchbot-adapter: 24テスト全パス
- [x] TypeScript型チェック: パス
- [x] ビルド: パス


Made with [Cursor](https://cursor.com)